### PR TITLE
Remove 44813449 (Medical contraindication to ear syringing) from concept set 285

### DIFF
--- a/concept_sets/285.json
+++ b/concept_sets/285.json
@@ -28,25 +28,6 @@
         "isExcluded": false,
         "includeDescendants": false,
         "includeMapped": false
-      },
-      {
-        "concept": {
-          "conceptId": 44813449,
-          "conceptName": "Medical contraindication to ear syringing",
-          "domainId": "Observation",
-          "vocabularyId": "SNOMED",
-          "conceptClassId": "Context-dependent",
-          "standardConcept": "S",
-          "standardConceptCaption": "Standard",
-          "conceptCode": "784911000000106",
-          "validStartDate": "2011-10-03",
-          "validEndDate": "2099-12-31",
-          "invalidReason": null,
-          "invalidReasonCaption": "Valid"
-        },
-        "isExcluded": false,
-        "includeDescendants": false,
-        "includeMapped": false
       }
     ]
   },

--- a/concept_sets_resolved/285.json
+++ b/concept_sets_resolved/285.json
@@ -2,15 +2,6 @@
   "conceptSetId": 285,
   "resolvedConcepts": [
     {
-      "conceptId": 44813449,
-      "conceptName": "Medical contraindication to ear syringing",
-      "vocabularyId": "SNOMED",
-      "domainId": "Observation",
-      "conceptClassId": "Context-dependent",
-      "conceptCode": "784911000000106",
-      "standardConcept": "S"
-    },
-    {
       "conceptId": 4141768,
       "conceptName": "Medical contraindication to procedure",
       "vocabularyId": "SNOMED",


### PR DESCRIPTION
The meaning of the concept set is "Contraindication to enteral feeding". The removed concept 44813449 "Medical contraindication to ear syringing" does not seem related to this meaning.